### PR TITLE
リファクタリングとソート時の重複するファイル名をはじく実装

### DIFF
--- a/donkoProject/src/main/java/controller/customer/OptionServlet.java
+++ b/donkoProject/src/main/java/controller/customer/OptionServlet.java
@@ -41,7 +41,7 @@ public class OptionServlet extends HttpServlet {
         request.getRequestDispatcher(view).forward(request, response);
 	}
 	
-	protected static String checkedOption(String categoryName, String[] checkedOption) {
+	private static String checkedOption(String categoryName, String[] checkedOption) {
 		String str = "[ " + categoryName + " ], [ " + checkedOption[0] + " ]";
 	    for (int index = 1; index < checkedOption.length; index++) {
 	        str += ", " + "[ " + checkedOption[index] + " ]";

--- a/donkoProject/src/main/java/controller/customer/OptionServlet.java
+++ b/donkoProject/src/main/java/controller/customer/OptionServlet.java
@@ -25,24 +25,24 @@ public class OptionServlet extends HttpServlet {
 		String[] checkedOption = request.getParameterValues("option");
 		String categoryName = request.getParameter("categoryName");
 		
-		// オプション選択した一覧
-		ArrayList<ItemBean> OCList = Item.getItemListByOption(checkedOption, categoryName);
 		// オプション選択の取得
 		ItemBean itemBean = new ItemBean();
 		itemBean.setItemCategoryName(categoryName);
 		ArrayList<ArrayList<OptionCategoryBean>> ONValueListALL = OptionCategory.getOptionCategoryListAllByCategory(itemBean);
+		// オプション選択した一覧
+		ArrayList<ItemBean> OCList = Item.getItemListByOption(checkedOption, categoryName);
 		
 		request.setAttribute("categoryName", categoryName);
 		request.setAttribute("ONValueListALL", ONValueListALL);
 		request.setAttribute("itemList", OCList);
-		request.setAttribute("message", "検索キーワード : " + checkedOption(checkedOption));
+		request.setAttribute("message", "検索キーワード : " + checkedOption(categoryName, checkedOption));
 		
 		String view = "/WEB-INF/views/customer/categoryIndex.jsp";
         request.getRequestDispatcher(view).forward(request, response);
 	}
 	
-	protected static String checkedOption(String[] checkedOption) {
-		String str = "[ " + checkedOption[0] + " ]";
+	protected static String checkedOption(String categoryName, String[] checkedOption) {
+		String str = "[ " + categoryName + " ], [ " + checkedOption[0] + " ]";
 	    for (int index = 1; index < checkedOption.length; index++) {
 	        str += ", " + "[ " + checkedOption[index] + " ]";
 	    }

--- a/donkoProject/src/main/java/model/items/itemsSelect/SelectItemListFromItemsByOption.java
+++ b/donkoProject/src/main/java/model/items/itemsSelect/SelectItemListFromItemsByOption.java
@@ -18,20 +18,21 @@ public class SelectItemListFromItemsByOption {
 				+ "INNER JOIN option_categories ON "
 				+ "options.option_category_name = option_categories.option_category_name AND "
 				+ "options.option_category_increment_id = option_categories.option_category_increment_id "
-				+ "WHERE option_categories.option_category_value IN (" + checkedOption(checkedOption) + ") "
-				+ "AND items.item_category_name = ?";
+				+ "WHERE items.item_category_name = ? "
+				+ "AND option_categories.option_category_value IN (" + questionNum(checkedOption) + ")";
 
 		ArrayList<Object> paramLists = new ArrayList<>() {{
+			add(categoryName);
 			for (int index = 0; index < checkedOption.length; index++) {
 		        add(checkedOption[index]);
 		    }
-			add(categoryName);
 		}};
 		ArrayList<ItemBean> OptionList = new ArrayList<>();
 		try (Connection conn = DatabaseConnection.getConnection()) {
 			try (ResultSet result = GeneralDao.executeQuery(conn, SELECT_OPTION_ITEMLIST_SQL, paramLists)) {
 				
-				while(result.next()){ 
+				// 1回目
+				if(result.next()){ 
 					ItemBean IBeans = new ItemBean();
 					int itemId = result.getInt("item_id");
 					String itemName = result.getString("item_name");
@@ -40,6 +41,22 @@ public class SelectItemListFromItemsByOption {
 					IBeans.setItemName(itemName);
 					IBeans.setImageFileName(imageFileName);
 					OptionList.add(IBeans);
+				}
+				
+				// 2回目以降
+				while(result.next()){ 
+					ItemBean IBeans = new ItemBean();
+					int itemId = result.getInt("item_id");
+					String itemName = result.getString("item_name");
+					String imageFileName = result.getString("file_name");
+					
+					boolean isNotExist = isNotExist(OptionList, imageFileName);
+					if (isNotExist == true) {
+						IBeans.setItemId(itemId);
+						IBeans.setItemName(itemName);
+						IBeans.setImageFileName(imageFileName);
+						OptionList.add(IBeans);
+					}
 				}
 				
 			} catch (SQLException e) {
@@ -55,11 +72,27 @@ public class SelectItemListFromItemsByOption {
 		return OptionList;
 	};
 	
-	public static String checkedOption(String[] checkedOption) {
+	protected static String questionNum(String[] checkedOption) {
 		String str = "?";
 	    for (int index = 1; index < checkedOption.length; index++) {
 	        str += ",?";
 	    }
 	    return str;
+	}
+	
+	protected static boolean isNotExist(ArrayList<ItemBean> OptionList, String imageFileName) {
+		boolean isNotExist = false;
+		for (int i = 0; i < OptionList.size(); i++) {
+			// i番目のファイル名の取得
+			ItemBean IB = OptionList.get(i);
+			String FN_num_i = IB.getImageFileName();
+			
+			if (!imageFileName.equals(FN_num_i)) {
+				isNotExist = true;
+			} else {
+				isNotExist = false;
+			}
+		}
+		return isNotExist;
 	}
 }

--- a/donkoProject/src/main/java/model/items/itemsSelect/SelectItemListFromItemsByOption.java
+++ b/donkoProject/src/main/java/model/items/itemsSelect/SelectItemListFromItemsByOption.java
@@ -72,7 +72,7 @@ public class SelectItemListFromItemsByOption {
 		return OptionList;
 	};
 	
-	protected static String questionNum(String[] checkedOption) {
+	private static String questionNum(String[] checkedOption) {
 		String str = "?";
 	    for (int index = 1; index < checkedOption.length; index++) {
 	        str += ",?";
@@ -80,7 +80,7 @@ public class SelectItemListFromItemsByOption {
 	    return str;
 	}
 	
-	protected static boolean isNotExist(ArrayList<ItemBean> OptionList, String imageFileName) {
+	private static boolean isNotExist(ArrayList<ItemBean> OptionList, String imageFileName) {
 		boolean isNotExist = false;
 		for (int i = 0; i < OptionList.size(); i++) {
 			// i番目のファイル名の取得

--- a/donkoProject/src/main/java/model/items/itemsSelect/SelectItemListFromItemsByOption.java
+++ b/donkoProject/src/main/java/model/items/itemsSelect/SelectItemListFromItemsByOption.java
@@ -91,6 +91,7 @@ public class SelectItemListFromItemsByOption {
 				isNotExist = true;
 			} else {
 				isNotExist = false;
+				break;
 			}
 		}
 		return isNotExist;

--- a/donkoProject/src/main/webapp/WEB-INF/views/customer/categoryIndex.jsp
+++ b/donkoProject/src/main/webapp/WEB-INF/views/customer/categoryIndex.jsp
@@ -22,7 +22,7 @@
 				String message = (String) request.getAttribute("message");
 				%>
 				<% if (message != null) { %>
-				<span class="border ms-4 py-2 px-3 w-auto" style="display: inline-flex; vertical-align: middle;"><%= message %></span>
+				<p class="border ms-4 my-auto py-2 px-3 w-auto" style="display: inline-flex; vertical-align: middle;"><%= message %></p>
 				<% } %>
 				<div class="col-lg-6 d-flex border ms-auto me-3 p-3" style="width:auto; height: 70px; box-shadow:5px 5px 5px lightgray;">
 					<% 


### PR DESCRIPTION
ソート時にfile_nameが重複しているものをはじくという実装に関して。

「緑、S」というキーワードでソートすると、
緑は重複をはじくことができたが、サイズの方ははじくことができていない。

大枠はできたのでひとまずプルリクを出します。

