### PR TITLE
配送先編集の修正

### DIFF
--- a/donkoProject/src/main/webapp/WEB-INF/views/customer/editShippingAddress.jsp
+++ b/donkoProject/src/main/webapp/WEB-INF/views/customer/editShippingAddress.jsp
@@ -29,7 +29,7 @@
             <strong>配送先編集</strong>
           </h2>
           <div>
-            <a href="myPage"
+            <a href="shippingAddressIndex"
               style="text-decoration: none; text-align: center;"><button
                 type="button" class="btn-close border" aria-label="Close"></button>️</a>
           </div>


### PR DESCRIPTION
キャンセルボタンのリンク先がマイページになっていたので、配送先一覧に修正しました。
確認お願いします。