### PR TITLE
生年月日の表示修正

### DIFF
--- a/donkoProject/src/main/webapp/WEB-INF/views/customer/myPage.jsp
+++ b/donkoProject/src/main/webapp/WEB-INF/views/customer/myPage.jsp
@@ -84,7 +84,13 @@
 									</tr>
 									<tr>
 										<td>誕生日</td>
+									<%
+                    if (users.getBirthday() == null) {
+                    %>
+                    <td>未設定</td>
+                    <% } else { %>
 										<td><%=new SimpleDateFormat("yyyy/MM/dd").format(users.getBirthday())%></td>
+										<% } %>
 									</tr>
 								</tbody>
 							</table>


### PR DESCRIPTION
生年月日が設定されていない状態で、購入履歴に閲覧できないため
Nullチェックを追加しました。