### PR TITLE
購入詳細画面

### DIFF
--- a/donkoProject/.classpath
+++ b/donkoProject/.classpath
@@ -22,26 +22,6 @@
 	<classpathentry kind="lib" path="src/main/webapp/WEB-INF/lib/jboss-logging-3.3.0.Final.jar"/>
 	<classpathentry kind="lib" path="src/main/webapp/WEB-INF/lib/slf4j-api-1.6.1 2.jar"/>
 	<classpathentry kind="lib" path="src/main/webapp/WEB-INF/lib/validation-api-2.0.1.Final.jar"/>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
-		<attributes>
-			<attribute name="test" value="true"/>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="test" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/donkoProject/src/main/java/controller/customer/PurchaseConfirmServlet.java
+++ b/donkoProject/src/main/java/controller/customer/PurchaseConfirmServlet.java
@@ -44,13 +44,6 @@ public class PurchaseConfirmServlet extends HttpServlet {
 		//ログインしているユーザーのメインの配送先を取得
 		ShippingAddressBean shippingAddress = ShippingAddress.getMainShippingAddress(customerUser);
 		
-		//メイン配送先を取得できなかった場合
-		if(shippingAddress == null) {
-			// エラー画面に遷移
-			ErrorHandling.transitionToErrorPage(request,response,"配送先情報の取得時に問題が発生しました。","shippingAddressIndex","配送先一覧画面に");
-			return;
-		}
-		
 		//ログインしているユーザーがカートに追加した商品を全て取得
 		ArrayList<CartBean> cartBeanList = Cart.getItemListFromCart(customerUser);
 		

--- a/donkoProject/src/main/webapp/WEB-INF/views/customer/purchaseConfirm.jsp
+++ b/donkoProject/src/main/webapp/WEB-INF/views/customer/purchaseConfirm.jsp
@@ -39,36 +39,54 @@
 									￥ <%= String.format("%,d", totalPrice) %>
 								</h4>
 							</div>
-							<form action="purchaseConfirm" method="post" class="ms-auto">
-								<input type="hidden" value="<%= totalPrice %>" name="totalPrice">
-								<input type="hidden" value="<%= sa.getAddress() %>" name="address">
-								<input type="hidden" value="<%= sa.getPostalCode() %>" name="postalCode">
-								<input type="hidden" value="<%= sa.getAddressee() %>" name="addressee">
-								<button type=submit class="btn px-5 py-2" style="background-color: #9933ff; color: white;">
-									注文確定
-								</button>
-							</form>
+							<%
+							if (sa != null){
+							%>
+								<form action="purchaseConfirm" method="post" class="ms-auto">
+									<input type="hidden" value="<%= totalPrice %>" name="totalPrice">
+									<input type="hidden" value="<%= sa.getAddress() %>" name="address">
+									<input type="hidden" value="<%= sa.getPostalCode() %>" name="postalCode">
+									<input type="hidden" value="<%= sa.getAddressee() %>" name="addressee">
+									<button type=submit class="btn px-5 py-2" style="background-color: #9933ff; color: white;">
+										注文確定
+									</button>
+								</form>
+							<%	
+							}
+							%>
 						</div>
 						<p class="mt-5">
 							1. 配送先
 						</p>
 						<hr>
 						<div class="p-3">
-							<p class="mb-0">
-								〒 
-								<%= new StringBuilder(sa.getPostalCode()).insert(3, "-") %>
-							</p>
-							<p>
-								<%= sa.getAddress() %>
-							</p>
-							<p>
-								<%= sa.getAddressee() %>
-							</p>
-							<div class="d-flex justify-content-end">
+							<%
+							if(sa != null){
+							%>
+								<p class="mb-0">
+									〒 
+									<%= new StringBuilder(sa.getPostalCode()).insert(3, "-") %>
+								</p>
+								<p>
+									<%= sa.getAddress() %>
+								</p>
+								<p>
+									<%= sa.getAddressee() %>
+								</p>
+								<div class="d-flex justify-content-end">
+									<a href="shippingAddressIndex" style="color: #385a37">
+										メインの配送先を変更
+									</a>
+								</div>
+							<%
+							} else {
+							%>
 								<a href="shippingAddressIndex" style="color: #385a37">
-									メインの配送先を変更
+									住所を設定してください
 								</a>
-							</div>
+							<%
+							} 
+							%>
 						</div>
 						<p>
 							2. 商品情報


### PR DESCRIPTION
新規ユーザーは配送先設定してないから、エラーページより設定のリンクに変えた方がいいかと思って変えました。

購入確定のボタンを配送先ない時消すようにしました