### PR TITLE
配送先一覧をメイン配送先でソートする機能のテスト

### DIFF
--- a/donkoProject/src/main/java/test/model/shippingAddress/shippingAddressesSelect/TestSelectMainShippingAddressSort.java
+++ b/donkoProject/src/main/java/test/model/shippingAddress/shippingAddressesSelect/TestSelectMainShippingAddressSort.java
@@ -1,0 +1,33 @@
+package test.model.shippingAddress.shippingAddressesSelect;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import bean.ShippingAddressBean;
+import classes.user.CustomerUser;
+import model.shippingAddresses.shippingAddressesSelect.SelectMainShippingAddressSort;
+
+class TestSelectMainShippingAddressSort {
+
+	//成功テスト
+	@Test
+	void testSuccess() {
+		CustomerUser customerUser = new CustomerUser();
+		customerUser.setUserId(4);
+		ArrayList<ShippingAddressBean> result = SelectMainShippingAddressSort.selectMainShippingAddressSort(customerUser);
+		assertTrue(result instanceof ArrayList<ShippingAddressBean>);
+	}
+	
+	//失敗テスト
+	@Test
+	void testException() {
+		CustomerUser customerUser = new CustomerUser();
+		customerUser.setUserId(0);
+		ArrayList<ShippingAddressBean> result = SelectMainShippingAddressSort.selectMainShippingAddressSort(customerUser);
+		assertNull(result);
+	}
+
+}


### PR DESCRIPTION
成功ケースのみ実施。
失敗ケースは後ほど。